### PR TITLE
Add parsing for paths like /user/{id}

### DIFF
--- a/src/classes/request-method.ts
+++ b/src/classes/request-method.ts
@@ -26,6 +26,14 @@ export class RequestMethod {
             data: {}
         }) => {
             let path = `${this.path}/${method.path}`.replace(/\/\//g, '/');
+            // If the path has an {id} parameter, replace it with the id
+            if (path.match('{id}')) {
+                if (!options.data.id) {
+                    return Promise.reject(`${path} has an id field in its path, but no id was provided in the data object`)
+                }
+                path = path.replace('{id}', options.data.id);
+                delete options.data.id;
+            }
             let client = method.requiresAuth ? this.client.getAuthAgent(options.headers) : this.client.getPublicAgent(options.headers);
 
             let promise;

--- a/src/resources/users.ts
+++ b/src/resources/users.ts
@@ -33,6 +33,14 @@ export default {
             path: '',
             required: ['email'],
             requiresAuth: true
+        }),
+
+        instanceOfRequestMethod({
+            name: 'show',
+            method: 'GET',
+            path: '{id}',
+            required: [],
+            requiresAuth: true
         })
     ]
 } as ResourceInterface


### PR DESCRIPTION
A simple add, where the `id` field is taken from the data object and substituted into the path.