### PR TITLE
Remove trailing slash

### DIFF
--- a/src/classes/request-method.ts
+++ b/src/classes/request-method.ts
@@ -22,7 +22,7 @@ export class RequestMethod {
 
     _request(method: RequestMethodInterface): any {
         return (data: any = {}, headers: any = {}) => {
-            let path = `${this.path}/${method.path}`.replace(/\/\//g, '/');
+            let path = `${this.path}${method.path}`.replace(/\/\//g, '/');
           
             // If the path has an {id} parameter, replace it with the id
             if (path.match('{id}')) {

--- a/src/resources/auth.ts
+++ b/src/resources/auth.ts
@@ -8,7 +8,7 @@ export default {
         instanceOfRequestMethod({
             name: 'create',
             method: 'POST',
-            path: 'token',
+            path: '/token',
             required: ['email', 'password'],
             requiresAuth: false
         }),
@@ -16,7 +16,7 @@ export default {
         instanceOfRequestMethod({
             name: 'refresh',
             method: 'POST',
-            path: 'token/refresh',
+            path: '/token/refresh',
             required: ['refresh_token'],
         }),
     ]

--- a/src/resources/users.ts
+++ b/src/resources/users.ts
@@ -8,7 +8,7 @@ export default {
         instanceOfRequestMethod({
             name: 'create',
             method: 'POST',
-            path: 'register',
+            path: '/register',
             required: [
                 'first_name',
                 'last_name',
@@ -22,7 +22,7 @@ export default {
         instanceOfRequestMethod({
             name: 'current',
             method: 'GET',
-            path: 'me',
+            path: '/me',
             required: [],
             requiresAuth: true
         }),
@@ -38,7 +38,7 @@ export default {
         instanceOfRequestMethod({
             name: 'show',
             method: 'GET',
-            path: '{id}',
+            path: '/{id}',
             required: [],
             requiresAuth: true
         })


### PR DESCRIPTION
Method paths like '' will resolve to `http://host/endpoint/`, which the API rejects as not found.

By asking the leading slash to be part of `method.path`, we can avoid this bug.