### PR TITLE
Switch register user test to expect status 201

### DIFF
--- a/db-seed/tests/01_users.js
+++ b/db-seed/tests/01_users.js
@@ -28,7 +28,7 @@ describe('Users', function() {
         users.forEach(function (user) {
             it(`registers ${user.first_name} ${user.last_name}`, async function () {
                 let result = await addUser(server, user);
-                assert.strictEqual(result.status, 200, `${user.last_name} was not added`);
+                assert.strictEqual(result.status, 201, `${user.last_name} was not added`);
             });
         });
     });


### PR DESCRIPTION
This branch should be merged in after https://github.com/big-neon/bn-api/pull/254 is. 

That associated PR changes the bn-api response for the register endpoint to return 201 (CREATED) instead of 200 (OK).